### PR TITLE
Fix monitor loop exiting with exception in action.

### DIFF
--- a/senseme/lib/background_monitor.py
+++ b/senseme/lib/background_monitor.py
@@ -6,7 +6,9 @@ may happen if the daemon dies while writing.
 """
 import time
 import threading
+import logging
 
+LOGGER = logging.getLogger(__name__)
 
 class BackgroundLoop:
     def __init__(self, interval=45, action=None):
@@ -22,7 +24,12 @@ class BackgroundLoop:
 
     def _loop(self):
         while self.should_continue:
-            self.action()
+            try:
+                self.action()
+            except Exception as e:
+                # catch all exceptions to prevent loop from exiting
+                # when not intended
+                LOGGER.error("Background task Exception: %s" % str(e))
             time.sleep(self.interval)
 
     def start(self):

--- a/senseme/lib/background_monitor.py
+++ b/senseme/lib/background_monitor.py
@@ -26,10 +26,10 @@ class BackgroundLoop:
         while self.should_continue:
             try:
                 self.action()
-            except Exception as e:
+            except Exception:
                 # catch all exceptions to prevent loop from exiting
                 # when not intended
-                LOGGER.error("Background task Exception: %s" % str(e))
+                LOGGER.exception("Background task error")
             time.sleep(self.interval)
 
     def start(self):


### PR DESCRIPTION
I don't know if you were looking for a pull request that would correct issue #25 but here is my take on fixing it.

Since _get_all_bare() is used in multiple places it should continue to produce exceptions and the calling code should decide what to do based on the exception. So _loop() in background_monitor.py should get the exception handling code.

In my code I catch ALL exceptions and some would say this is bad form. In this particular instance I don't think that is the case. Since this a thread running in the background there is no way pass the exceptions up without causing the background _loop() to stop executing. Actually catching exceptions, logging them and then allowing the _loop to try again later is reasonable.
